### PR TITLE
use base name

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "safer-globe-arms-report",
   "version": "0.1.0",
   "private": true,
+  "homepage": "/armsreport",
   "devDependencies": {
     "autoprefixer": "^7.1.1",
     "eslint": "^3.19.0",

--- a/src/index.js
+++ b/src/index.js
@@ -465,7 +465,7 @@ We have to wrap our main app component in a generic <Route /> like this
 so we get the `location` in props
 */
 const AppRouterWrap = () => (
-  <Router>
+  <Router basename="/armsreport">
     <Route component={AppRouter} />
   </Router>
 );


### PR DESCRIPTION
This should let the app run in the deployment environment at https://saferglobe.fi/armsreport - but need to make sure it still works in the heroku deployment too.